### PR TITLE
Fix document.visibilityState for initially hidden pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,3 +95,7 @@ Check "Manual instrumentation" in README for new instructions.
 - Extended `document.visbilityState` discoverability for root spans
 - Fixed broken span timings on some browsers
 - XHR & longtask metrics
+
+## Unreleased
+
+- Fixed `document.visibilityState` for pages open in background

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ Then clone the repo and run `npm install` for installing required development de
 
 ```text
 git clone --recurse-submodules https://github.com/SumoLogic/sumologic-opentelemetry-js.git
+nvm use
 npm install
 npm run build
 ```

--- a/src/sumologic-span-processor/document-visibility-state.ts
+++ b/src/sumologic-span-processor/document-visibility-state.ts
@@ -61,6 +61,9 @@ window.addEventListener('pageshow', () => {
 export const onStart = (span: SdkTraceSpan, context?: Context): void => {
   span.setAttribute(ATTRIBUTE_NAME, initialState);
 
+  // We need to check history of changes, because span can be created with a custom time.
+  // This is a common situation in document-load auto-instrumentation, when spans are created
+  // with page loading times, when the RUM script was not yet initialized.
   const startTimeInNanoseconds = hrTimeToNanoseconds(span.startTime);
   for (let i = changes.length - 1; i >= 0; i -= 1) {
     const { timestampInNanoseconds, state } = changes[i];
@@ -82,8 +85,6 @@ export const onEnd = (readableSpan: ReadableSpan): void => {
     ? hrTimeToNanoseconds(span.endTime)
     : Infinity;
 
-  // we skip the initial change because it's already covered by the onStart function
-  // and we don't want to save initial state as an event
   for (let i = changes.length - 1; i >= 0; i -= 1) {
     const { timestampInNanoseconds, timestampInHrTime, state } = changes[i];
     if (timestampInNanoseconds < startTimeInNanoseconds) {

--- a/src/sumologic-span-processor/index.spec.ts
+++ b/src/sumologic-span-processor/index.spec.ts
@@ -144,6 +144,20 @@ describe('SumoLogicSpanProcessor', () => {
       expect(span.attributes['document.visibilityState']).toBe('hidden');
     });
 
+    test('when page was initially open hidden', () => {
+      setDocumentVisibilityState('hidden');
+      resetDocumentVisibilityStateChanges();
+      // span can be created with a timestamp before RUM script run, e.g. in document-load
+      setSystemTime('2022-01-01 09:00');
+      span = createSpan();
+      spanProcessor.onStart(span);
+      setSystemTime('2022-01-01 09:02');
+      span.end();
+      spanProcessor.onEnd(span);
+      jest.runAllTimers();
+      expect(span.attributes['document.visibilityState']).toBe('hidden');
+    });
+
     test('when page becomes hidden using "pagehide" event', () => {
       spanProcessor.onStart(span);
       setDocumentVisibilityState('hidden');


### PR DESCRIPTION
In case when page was open in background, we want to populate documentLoad spans with the proper document.visibilityState.