### PR TITLE
Don't use document & window objects if undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,14 +83,17 @@ interface InitializeOptions {
 }
 
 const useWindow = typeof window === 'object' && window != null;
+const useDocument = typeof document === 'object' && document != null;
+
+let contextManager: SumoLogicContextManager | undefined
 
 if (useWindow) {
   window.sumoLogicOpenTelemetryRum = window.sumoLogicOpenTelemetryRum || {};
-}
 
-// create context manager right now to patch APIs for situations when 'initialize' is called later
-const contextManager = new SumoLogicContextManager();
-contextManager.enable();
+  // create context manager right now to patch APIs for situations when 'initialize' is called later
+  contextManager = new SumoLogicContextManager();
+  contextManager.enable();
+}
 
 export const initialize = ({
   collectionSourceUrl,
@@ -111,6 +114,8 @@ export const initialize = ({
   userInteractionElementNameLimit = DEFAULT_USER_INTERACTION_ELEMENT_NAME_LIMIT,
   getOverriddenServiceName,
 }: InitializeOptions) => {
+  if (!useWindow) return;
+
   if (!collectionSourceUrl) {
     throw new Error(
       'collectionSourceUrl needs to be defined to initialize Sumo Logic OpenTelemetry RUM',
@@ -229,7 +234,7 @@ export const initialize = ({
           new LongTaskInstrumentation({
             enabled: false,
           }),
-          new DocumentLoadInstrumentation({ enabled: false }),
+          ...(useDocument ? [new DocumentLoadInstrumentation({ enabled: false })] : []),
           new UserInteractionInstrumentation({
             enabled: false,
             eventNames: INSTRUMENTED_EVENT_NAMES,

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,6 @@ interface InitializeOptions {
 }
 
 const useWindow = typeof window === 'object' && window != null;
-const useDocument = typeof document === 'object' && document != null;
 
 let contextManager: SumoLogicContextManager | undefined;
 
@@ -234,9 +233,7 @@ export const initialize = ({
           new LongTaskInstrumentation({
             enabled: false,
           }),
-          ...(useDocument
-            ? [new DocumentLoadInstrumentation({ enabled: false })]
-            : []),
+          new DocumentLoadInstrumentation({ enabled: false }),
           new UserInteractionInstrumentation({
             enabled: false,
             eventNames: INSTRUMENTED_EVENT_NAMES,

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ interface InitializeOptions {
 const useWindow = typeof window === 'object' && window != null;
 const useDocument = typeof document === 'object' && document != null;
 
-let contextManager: SumoLogicContextManager | undefined
+let contextManager: SumoLogicContextManager | undefined;
 
 if (useWindow) {
   window.sumoLogicOpenTelemetryRum = window.sumoLogicOpenTelemetryRum || {};
@@ -234,7 +234,9 @@ export const initialize = ({
           new LongTaskInstrumentation({
             enabled: false,
           }),
-          ...(useDocument ? [new DocumentLoadInstrumentation({ enabled: false })] : []),
+          ...(useDocument
+            ? [new DocumentLoadInstrumentation({ enabled: false })]
+            : []),
           new UserInteractionInstrumentation({
             enabled: false,
             eventNames: INSTRUMENTED_EVENT_NAMES,

--- a/src/sumologic-span-processor/document-visibility-state.ts
+++ b/src/sumologic-span-processor/document-visibility-state.ts
@@ -27,10 +27,6 @@ let currentState = initialState;
 
 // exported for tests
 export const resetDocumentVisibilityStateChanges = () => {
-  if (!useDocument) {
-    return;
-  }
-
   while (changes.length) {
     changes.pop();
   }
@@ -39,10 +35,6 @@ export const resetDocumentVisibilityStateChanges = () => {
 };
 
 const updateState = () => {
-  if (!useDocument) {
-    return;
-  }
-
   const newState = document?.visibilityState;
   if (currentState !== newState) {
     currentState = newState;

--- a/src/sumologic-span-processor/document-visibility-state.ts
+++ b/src/sumologic-span-processor/document-visibility-state.ts
@@ -4,7 +4,7 @@ import {
   ReadableSpan,
   Span as SdkTraceSpan,
 } from '@opentelemetry/sdk-trace-base';
-import { useDocument, useWindow } from "./utils";
+import { useDocument, useWindow } from './utils';
 
 // @todo: remove when typescript gets updated
 type DocumentVisibilityState = typeof window.document.visibilityState;

--- a/src/sumologic-span-processor/session-id.ts
+++ b/src/sumologic-span-processor/session-id.ts
@@ -1,7 +1,7 @@
 import { Context } from '@opentelemetry/api';
 import { RandomIdGenerator } from '@opentelemetry/core';
 import { Span as SdkTraceSpan } from '@opentelemetry/sdk-trace-base';
-import { useDocument } from "./utils";
+import { useDocument } from './utils';
 
 interface Cookie {
   sessionId: string;
@@ -33,7 +33,7 @@ const setCookieValue = ({ sessionId, lastActivityTimestamp }: Cookie): void => {
 };
 
 const idGenerator = new RandomIdGenerator();
-let cookie: Cookie | undefined
+let cookie: Cookie | undefined;
 
 if (useDocument) {
   cookie = getCookieValue();

--- a/src/sumologic-span-processor/session-id.ts
+++ b/src/sumologic-span-processor/session-id.ts
@@ -15,10 +15,6 @@ const MAX_INACTIVITY_MS = 1000 * 60 * 5; // 5 minutes
 const REFRESH_ACTIVITY_TIME_AFTER_MS = 1000 * 30; // 30 seconds
 
 const getCookieValue = (): Cookie | undefined => {
-  if (!useDocument) {
-    return;
-  }
-
   const cookie = document.cookie
     .split('; ')
     .find((item) => item.startsWith(`${COOKIE_NAME}=`));
@@ -33,15 +29,15 @@ const getCookieValue = (): Cookie | undefined => {
 };
 
 const setCookieValue = ({ sessionId, lastActivityTimestamp }: Cookie): void => {
-  if (!useDocument) {
-    return;
-  }
-
   document.cookie = `${COOKIE_NAME}=${sessionId}${COOKIE_VALUE_SEPARATOR}${lastActivityTimestamp}; path=/`;
 };
 
 const idGenerator = new RandomIdGenerator();
-let cookie = getCookieValue();
+let cookie: Cookie | undefined
+
+if (useDocument) {
+  cookie = getCookieValue();
+}
 
 // exported for unit tests
 export const resetSessionIdCookie = () => {
@@ -74,5 +70,7 @@ export const getCurrentSessionId = () => {
 };
 
 export const onStart = (span: SdkTraceSpan, context?: Context): void => {
+  if (!useDocument) return;
+
   span.setAttribute(SESSION_ID_ATTRIBUTE, getCurrentSessionId());
 };

--- a/src/sumologic-span-processor/session-id.ts
+++ b/src/sumologic-span-processor/session-id.ts
@@ -1,6 +1,7 @@
 import { Context } from '@opentelemetry/api';
 import { RandomIdGenerator } from '@opentelemetry/core';
 import { Span as SdkTraceSpan } from '@opentelemetry/sdk-trace-base';
+import { useDocument } from "./utils";
 
 interface Cookie {
   sessionId: string;
@@ -14,6 +15,10 @@ const MAX_INACTIVITY_MS = 1000 * 60 * 5; // 5 minutes
 const REFRESH_ACTIVITY_TIME_AFTER_MS = 1000 * 30; // 30 seconds
 
 const getCookieValue = (): Cookie | undefined => {
+  if (!useDocument) {
+    return;
+  }
+
   const cookie = document.cookie
     .split('; ')
     .find((item) => item.startsWith(`${COOKIE_NAME}=`));
@@ -28,6 +33,10 @@ const getCookieValue = (): Cookie | undefined => {
 };
 
 const setCookieValue = ({ sessionId, lastActivityTimestamp }: Cookie): void => {
+  if (!useDocument) {
+    return;
+  }
+
   document.cookie = `${COOKIE_NAME}=${sessionId}${COOKIE_VALUE_SEPARATOR}${lastActivityTimestamp}; path=/`;
 };
 

--- a/src/sumologic-span-processor/utils.ts
+++ b/src/sumologic-span-processor/utils.ts
@@ -2,6 +2,9 @@ import { Span as SdkTraceSpan } from '@opentelemetry/sdk-trace-base';
 import { AttributeValue, SpanKind } from '@opentelemetry/api';
 import { XHR_IS_ROOT_SPAN } from '../constants';
 
+export const useWindow = typeof window === 'object' && window != null;
+export const useDocument = typeof document === 'object' && document != null;
+
 export const isXhrSpan = (span: SdkTraceSpan): boolean =>
   span.name.startsWith('HTTP ') && span.kind === SpanKind.CLIENT;
 


### PR DESCRIPTION
This is useful for Node environments (also SSR, e.g. NextJS)