### PR TITLE
Add permissions for fetching JWT token

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,8 +7,10 @@ on:
 
 jobs:
   publish:
+    permissions:
+      id-token: write
+      contents: read
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
As required by https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#adding-permissions-settings